### PR TITLE
Support recycling ColumnChunkData during DROP TABLE

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -164,7 +164,7 @@ void CatalogSet::dropEntry(Transaction* transaction, const std::string& name, oi
     /* For now, we only take care of node table */
     if (table->getTableType() == TableType::NODE) {
         auto *nodeTable = table->ptrCast<storage::NodeTable>();
-        std::vector<std::pair<page_idx_t, page_idx_t>> chunkPhysicInfo = nodeTable->getAllChunkPhysicInfoForColumn(INVALID_COLUMN_ID);
+        std::vector<std::pair<page_idx_t, page_idx_t>> chunkPhysicInfo = nodeTable->getAllChunkPhysicInfo();
         for(auto phyInfo : chunkPhysicInfo) {
             page_idx_t pageIdx = phyInfo.first;
             page_idx_t numPages = phyInfo.second;

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -1,5 +1,7 @@
 #include "catalog/catalog_set.h"
 
+#include <vector>
+
 #include "binder/ddl/bound_alter_info.h"
 #include "catalog/catalog_entry/dummy_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
@@ -7,6 +9,11 @@
 #include "common/exception/catalog.h"
 #include "common/serializer/deserializer.h"
 #include "common/string_format.h"
+#include "main/client_context.h"
+#include "storage/file_handle.h"
+#include "storage/store/table.h"
+#include "storage/store/node_table.h"
+#include "storage/storage_manager.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::common;
@@ -149,6 +156,25 @@ void CatalogSet::dropEntry(Transaction* transaction, const std::string& name, oi
         entryPtr = dropEntryNoLock(transaction, name, oid);
     }
     KU_ASSERT(entryPtr);
+
+    /* Now, register information of dropped column chunk data into FreeChunkMap */
+    auto* storageManager = transaction->getClientContext()->getStorageManager();
+    auto& freeChunkMap = storageManager->getDataFH()->getFreeChunkMap();
+    auto* table = storageManager->getTable(entryPtr->getOID());
+    /* For now, we only take care of node table */
+    if (table->getTableType() == TableType::NODE) {
+        auto *nodeTable = table->ptrCast<storage::NodeTable>();
+        std::vector<std::pair<page_idx_t, page_idx_t>> chunkPhysicInfo = nodeTable->getAllChunkPhysicInfoForColumn(INVALID_COLUMN_ID);
+        for(auto phyInfo : chunkPhysicInfo) {
+            page_idx_t pageIdx = phyInfo.first;
+            page_idx_t numPages = phyInfo.second;
+            /* Skip column chunk data that has no physical storage */
+            if (pageIdx != INVALID_PAGE_IDX && numPages != 0) {
+                freeChunkMap.AddFreeChunk(pageIdx, numPages);
+            }
+        }
+    }
+
     logEntryForTrx(transaction, *this, *entryPtr);
 }
 

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -160,6 +160,8 @@ public:
 
     virtual void flush(FileHandle& dataFH);
 
+    virtual std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo();
+
     ColumnChunkMetadata flushBuffer(FileHandle* dataFH, common::page_idx_t startPageIdx,
         const ColumnChunkMetadata& metadata) const;
 

--- a/src/include/storage/store/free_chunk_map.h
+++ b/src/include/storage/store/free_chunk_map.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <unordered_map>
 #include <vector>
+#include <set>
 
 #include "common/constants.h"
 #include "common/types/types.h"
@@ -74,8 +74,9 @@ public:
 private:
     FreeChunkLevel GetChunkLevel(common::page_idx_t numPages);
 
-    /* ERICTODO: Need partitioned locks here to protect each LInked list */
+    /*No need for locks here since only checkpoint will need free chunks when all other transactions are blocked */
     std::vector<FreeChunkEntry *> freeChunkList;
+    std::set<common::page_idx_t> existingFreeChunks;
     FreeChunkLevel maxAvailLevel;
 };
 

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -87,6 +87,8 @@ public:
         offsetColumnChunk->resize(newCapacity);
     }
 
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo() override;
+
     common::offset_t getListStartOffset(common::offset_t offset) const;
 
     common::offset_t getListEndOffset(common::offset_t offset) const;

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -148,8 +148,12 @@ public:
     virtual void addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState, FileHandle* dataFH);
 
+    /* This function retrieve the physical info of all column chunk datas of the given column */
     std::vector<std::pair<common::page_idx_t, common::page_idx_t>>
         getAllChunkPhysicInfoForColumn(common::column_id_t columnID);
+    /* This function retrieve the physical info of all column chunk datas of ALL columns */
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo();
+
     void flush(transaction::Transaction* transaction, FileHandle& dataFH);
 
     virtual void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state);
@@ -204,6 +208,9 @@ private:
 
     static void populateNodeID(common::ValueVector& nodeIDVector, common::table_id_t tableID,
         common::offset_t startNodeOffset, common::row_idx_t numRows);
+
+    void addChunkDataForColumn(common::column_id_t columnID, ChunkedNodeGroup &chunkedGroup,
+        std::vector<std::pair<common::page_idx_t, common::page_idx_t>> &chunkInfo);
 
 protected:
     common::node_group_idx_t nodeGroupIdx;

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -54,8 +54,11 @@ public:
         nodeGroups.clear(lock);
     }
 
+    /* This function retrieve the physical info of all column chunk datas of the given column */
     std::vector<std::pair<common::page_idx_t, common::page_idx_t>>
         getAllChunkPhysicInfoForColumn(common::column_id_t columnID);
+    /* This function retrieve the physical info of all column chunk datas of ALL columns */
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo();
 
     common::column_id_t getNumColumns() const { return types.size(); }
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -165,8 +165,8 @@ public:
         return nodeGroups->getNodeGroupNoLock(nodeGroupIdx);
     }
 
-    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfoForColumn(common::column_id_t columnID) {
-        return nodeGroups->getAllChunkPhysicInfoForColumn(columnID);
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo() {
+        return nodeGroups->getAllChunkPhysicInfo();
     }
 
 private:

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -165,6 +165,10 @@ public:
         return nodeGroups->getNodeGroupNoLock(nodeGroupIdx);
     }
 
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfoForColumn(common::column_id_t columnID) {
+        return nodeGroups->getAllChunkPhysicInfoForColumn(columnID);
+    }
+
 private:
     void insertPK(const transaction::Transaction* transaction,
         const common::ValueVector& nodeIDVector, const common::ValueVector& pkVector) const;

--- a/src/include/storage/store/string_chunk_data.h
+++ b/src/include/storage/store/string_chunk_data.h
@@ -75,6 +75,8 @@ public:
     void resize(uint64_t newCapacity) override;
     uint64_t getEstimatedMemoryUsage() const override;
 
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo() override;
+
     void serialize(common::Serializer& serializer) const override;
     static void deserialize(common::Deserializer& deSer, ColumnChunkData& chunkData);
 

--- a/src/include/storage/store/struct_chunk_data.h
+++ b/src/include/storage/store/struct_chunk_data.h
@@ -36,6 +36,8 @@ public:
         metadata.numValues = numValues;
     }
 
+    std::vector<std::pair<common::page_idx_t, common::page_idx_t>> getAllChunkPhysicInfo() override;
+
     void serialize(common::Serializer& serializer) const override;
     static void deserialize(common::Deserializer& deSer, ColumnChunkData& chunkData);
 

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -243,6 +243,23 @@ void ColumnChunkData::flush(FileHandle& dataFH) {
     }
 }
 
+std::vector<std::pair<page_idx_t, page_idx_t>> ColumnChunkData::getAllChunkPhysicInfo()
+{
+    std::vector<std::pair<page_idx_t, page_idx_t>> chunkInfo;
+    if (getResidencyState() == ResidencyState::ON_DISK) {
+        ColumnChunkMetadata& metadata = getMetadata();
+        /*
+         * It is possible for an ON_DISK chunk to have no storage assigned (i.e. min_val = max_val)
+         * Ignore such case here since no corresponding disk space information
+         */
+        if (metadata.pageIdx != INVALID_PAGE_IDX && metadata.numPages != 0) {
+            chunkInfo.push_back({metadata.pageIdx, metadata.numPages});
+        }
+    }
+
+    return chunkInfo;
+}
+
 // Note: This function is not setting child/null chunk data recursively.
 void ColumnChunkData::setToOnDisk(const ColumnChunkMetadata& metadata) {
     residencyState = ResidencyState::ON_DISK;

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -227,7 +227,7 @@ void ColumnChunkData::flush(FileHandle& dataFH) {
             if (freeChunkEntry->numPages != 0) {
                 freeChunkMap.AddFreeChunk(freeChunkEntry->pageIdx + preScanMetadata.numPages, freeChunkEntry->numPages);
             }
-            free(freeChunkEntry);
+            delete freeChunkEntry;
         }
     }
 

--- a/src/storage/store/free_chunk_map.cpp
+++ b/src/storage/store/free_chunk_map.cpp
@@ -30,6 +30,7 @@ FreeChunkMap::~FreeChunkMap() {
     }
 
     freeChunkList.clear();
+    existingFreeChunks.clear();
     maxAvailLevel = INVALID_FREE_CHUNK_LEVEL;
 }
 
@@ -62,7 +63,7 @@ FreeChunkLevel FreeChunkMap::GetChunkLevel(common::page_idx_t numPages)
  */
 FreeChunkEntry *FreeChunkMap::GetFreeChunk(common::page_idx_t numPages)
 {
-    /* return immediately if it does not want any pages */
+    /* 0. return immediately if it does not want any pages */
     if (numPages == 0) {
         return nullptr;
     }
@@ -111,8 +112,9 @@ FreeChunkEntry *FreeChunkMap::GetFreeChunk(common::page_idx_t numPages)
                     /* need to unlink it from its parent */
                     lastSearchEntry->nextEntry = curEntry->nextEntry;
                 }
-
                 curEntry->nextEntry = nullptr;
+                existingFreeChunks.erase(curEntry->pageIdx);
+
                 return curEntry;
             }
 
@@ -129,6 +131,12 @@ FreeChunkEntry *FreeChunkMap::GetFreeChunk(common::page_idx_t numPages)
 void FreeChunkMap::AddFreeChunk(common::page_idx_t pageIdx, common::page_idx_t numPages)
 {
     KU_ASSERT(pageIdx != INVALID_PAGE_IDX && numPages != 0);
+
+    /* 0. Make sure we do not have duplicate entry here */
+    if (existingFreeChunks.find(pageIdx) != existingFreeChunks.end()) {
+        KU_ASSERT(0);
+        return;
+    }
 
     /* 1. Get the corresponding ChunkLevel numPages belongs to */
     FreeChunkLevel curLevel = GetChunkLevel(numPages);
@@ -154,6 +162,7 @@ void FreeChunkMap::AddFreeChunk(common::page_idx_t pageIdx, common::page_idx_t n
         KU_ASSERT(curEntryInList != nullptr);
         curEntryInList->nextEntry = entry;
     }
+    existingFreeChunks.insert(pageIdx);
 }
 
 /* ERICTODO: Implement this for data persistency */

--- a/src/storage/store/free_chunk_map.cpp
+++ b/src/storage/store/free_chunk_map.cpp
@@ -18,7 +18,6 @@ FreeChunkMap::FreeChunkMap()
     for (int i = 0; i < MAX_FREE_CHUNK_LEVEL; i++) {
         freeChunkList.push_back(nullptr);
     }
-    maxAvailLevel = INVALID_FREE_CHUNK_LEVEL;
 };
 
 FreeChunkMap::~FreeChunkMap() {
@@ -136,7 +135,7 @@ void FreeChunkMap::AddFreeChunk(common::page_idx_t pageIdx, common::page_idx_t n
     KU_ASSERT(curLevel < MAX_FREE_CHUNK_LEVEL);
 
     /* 2. Create a new FreeChunkEntry */
-    FreeChunkEntry *entry = (FreeChunkEntry *)malloc(sizeof(FreeChunkEntry));
+    FreeChunkEntry *entry = new FreeChunkEntry;
     entry->pageIdx = pageIdx;
     entry->numPages = numPages;
 

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -423,17 +423,17 @@ std::vector<struct std::pair<page_idx_t, page_idx_t>> ListChunkData::getAllChunk
     if (getResidencyState() == ResidencyState::ON_DISK) {
         std::vector<struct std::pair<page_idx_t, page_idx_t>> curInfo;
         curInfo = offsetColumnChunk->getAllChunkPhysicInfo();
-        if (curInfo.size() != 0) {
+        if (!curInfo.empty()) {
             chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             curInfo.clear();
         }
         curInfo = sizeColumnChunk->getAllChunkPhysicInfo();
-        if (curInfo.size() != 0) {
+        if (!curInfo.empty()) {
             chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             curInfo.clear();
         }
         curInfo = dataColumnChunk->getAllChunkPhysicInfo();
-        if (curInfo.size() != 0) {
+        if (!curInfo.empty()) {
             chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             curInfo.clear();
         }

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -417,6 +417,31 @@ uint64_t ListChunkData::getEstimatedMemoryUsage() const {
            offsetColumnChunk->getEstimatedMemoryUsage();
 }
 
+std::vector<struct std::pair<page_idx_t, page_idx_t>> ListChunkData::getAllChunkPhysicInfo()
+{
+    std::vector<struct std::pair<page_idx_t, page_idx_t>> chunkInfo;
+    if (getResidencyState() == ResidencyState::ON_DISK) {
+        std::vector<struct std::pair<page_idx_t, page_idx_t>> curInfo;
+        curInfo = offsetColumnChunk->getAllChunkPhysicInfo();
+        if (curInfo.size() != 0) {
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            curInfo.clear();
+        }
+        curInfo = sizeColumnChunk->getAllChunkPhysicInfo();
+        if (curInfo.size() != 0) {
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            curInfo.clear();
+        }
+        curInfo = dataColumnChunk->getAllChunkPhysicInfo();
+        if (curInfo.size() != 0) {
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            curInfo.clear();
+        }
+    }
+
+    return chunkInfo;
+}
+
 void ListChunkData::serialize(Serializer& serializer) const {
     ColumnChunkData::serialize(serializer);
     serializer.writeDebuggingInfo("size_column_chunk");

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -235,29 +235,13 @@ std::vector<std::pair<page_idx_t, page_idx_t>> NodeGroup::getAllChunkPhysicInfoF
         if (columnID == INVALID_COLUMN_ID) {
             for (common::idx_t i = 0; i < chunkedGroup->getNumColumns(); i++) {
                 ColumnChunkData &chunkData = chunkedGroup->getColumnChunk(i).getData();
-                if (chunkData.getResidencyState() == ResidencyState::ON_DISK) {
-                    ColumnChunkMetadata& metadata = chunkData.getMetadata();
-                    /*
-                     * It is possible for an ON_DISK chunk to have no storage assigned (i.e. min_val = max_val)
-                     * Ignore such case here since no corresponding disk space information
-                     */
-                    if (metadata.pageIdx != INVALID_PAGE_IDX && metadata.numPages != 0) {
-                        chunkInfo.push_back({metadata.pageIdx, metadata.numPages});
-                    }
-                }
+                std::vector<std::pair<page_idx_t, page_idx_t>> curInfo = chunkData.getAllChunkPhysicInfo();
+                chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             }
         } else {
             ColumnChunkData &chunkData = chunkedGroup->getColumnChunk(columnID).getData();
-            if (chunkData.getResidencyState() == ResidencyState::ON_DISK) {
-                ColumnChunkMetadata& metadata = chunkData.getMetadata();
-                /*
-                 * It is possible for an ON_DISK chunk to have no storage assigned (i.e. min_val = max_val)
-                 * Ignore such case here since no corresponding disk space information
-                 */
-                if (metadata.pageIdx != INVALID_PAGE_IDX && metadata.numPages != 0) {
-                    chunkInfo.push_back({metadata.pageIdx, metadata.numPages});
-                }
-            }
+            std::vector<std::pair<page_idx_t, page_idx_t>> curInfo = chunkData.getAllChunkPhysicInfo();
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
         }
     }
 

--- a/src/storage/store/node_group_collection.cpp
+++ b/src/storage/store/node_group_collection.cpp
@@ -184,7 +184,21 @@ std::vector<std::pair<page_idx_t, page_idx_t>>
     const auto lock = nodeGroups.lock();
     for (const auto& nodeGroup : nodeGroups.getAllGroups(lock)) {
         std::vector<std::pair<page_idx_t, page_idx_t>> nodeGroupInfo = nodeGroup->getAllChunkPhysicInfoForColumn(columnID);
-        if (nodeGroupInfo.size() != 0) {
+        if (!nodeGroupInfo.empty()) {
+            allChunkPhysicInfo.insert(allChunkPhysicInfo.end(), nodeGroupInfo.begin(), nodeGroupInfo.end());
+        }
+    }
+
+    return allChunkPhysicInfo;
+}
+
+std::vector<std::pair<page_idx_t, page_idx_t>> NodeGroupCollection::getAllChunkPhysicInfo()
+{
+    std::vector<std::pair<page_idx_t, page_idx_t>> allChunkPhysicInfo;
+    const auto lock = nodeGroups.lock();
+    for (const auto& nodeGroup : nodeGroups.getAllGroups(lock)) {
+        std::vector<std::pair<page_idx_t, page_idx_t>> nodeGroupInfo = nodeGroup->getAllChunkPhysicInfo();
+        if (!nodeGroupInfo.empty()) {
             allChunkPhysicInfo.insert(allChunkPhysicInfo.end(), nodeGroupInfo.begin(), nodeGroupInfo.end());
         }
     }

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -276,17 +276,17 @@ std::vector<struct std::pair<page_idx_t, page_idx_t>> StringChunkData::getAllChu
     if (getResidencyState() == ResidencyState::ON_DISK) {
         std::vector<struct std::pair<page_idx_t, page_idx_t>> curInfo;
         curInfo = indexColumnChunk->getAllChunkPhysicInfo();
-        if (curInfo.size() != 0) {
+        if (!curInfo.empty()) {
             chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             curInfo.clear();
         }
         curInfo = dictionaryChunk->getStringDataChunk()->getAllChunkPhysicInfo();
-        if (curInfo.size() != 0) {
+        if (!curInfo.empty()) {
             chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             curInfo.clear();
         }
         curInfo = dictionaryChunk->getOffsetChunk()->getAllChunkPhysicInfo();
-        if (curInfo.size() != 0) {
+        if (!curInfo.empty()) {
             chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             curInfo.clear();
         }

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -270,6 +270,31 @@ uint64_t StringChunkData::getEstimatedMemoryUsage() const {
     return ColumnChunkData::getEstimatedMemoryUsage() + dictionaryChunk->getEstimatedMemoryUsage();
 }
 
+std::vector<struct std::pair<page_idx_t, page_idx_t>> StringChunkData::getAllChunkPhysicInfo()
+{
+    std::vector<struct std::pair<page_idx_t, page_idx_t>> chunkInfo;
+    if (getResidencyState() == ResidencyState::ON_DISK) {
+        std::vector<struct std::pair<page_idx_t, page_idx_t>> curInfo;
+        curInfo = indexColumnChunk->getAllChunkPhysicInfo();
+        if (curInfo.size() != 0) {
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            curInfo.clear();
+        }
+        curInfo = dictionaryChunk->getStringDataChunk()->getAllChunkPhysicInfo();
+        if (curInfo.size() != 0) {
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            curInfo.clear();
+        }
+        curInfo = dictionaryChunk->getOffsetChunk()->getAllChunkPhysicInfo();
+        if (curInfo.size() != 0) {
+            chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            curInfo.clear();
+        }
+    }
+
+    return chunkInfo;
+}
+
 void StringChunkData::serialize(Serializer& serializer) const {
     ColumnChunkData::serialize(serializer);
     serializer.writeDebuggingInfo("index_column_chunk");

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -73,7 +73,7 @@ std::vector<struct std::pair<page_idx_t, page_idx_t>> StructChunkData::getAllChu
             auto *childChunk = getChild(index);
             std::vector<struct std::pair<page_idx_t, page_idx_t>> curInfo;
             curInfo = childChunk->getAllChunkPhysicInfo();
-            if (curInfo.size() != 0) {
+            if (!curInfo.empty()) {
                 chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
             }
         }

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -65,6 +65,23 @@ void StructChunkData::resetToAllNull() {
     }
 }
 
+std::vector<struct std::pair<page_idx_t, page_idx_t>> StructChunkData::getAllChunkPhysicInfo()
+{
+    std::vector<struct std::pair<page_idx_t, page_idx_t>> chunkInfo;
+    if (getResidencyState() == ResidencyState::ON_DISK) {
+        for (common::idx_t index = 0; index < getNumChildren(); index++) {
+            auto *childChunk = getChild(index);
+            std::vector<struct std::pair<page_idx_t, page_idx_t>> curInfo;
+            curInfo = childChunk->getAllChunkPhysicInfo();
+            if (curInfo.size() != 0) {
+                chunkInfo.insert(chunkInfo.end(), curInfo.begin(), curInfo.end());
+            }
+        }
+    }
+
+    return chunkInfo;
+}
+
 void StructChunkData::serialize(Serializer& serializer) const {
     ColumnChunkData::serialize(serializer);
     serializer.writeDebuggingInfo("struct_children");


### PR DESCRIPTION
1. Add logic to add FreeChunkEntry for possible recyclable ColumnChunkData from DROP TABLE
2. Support recycle ColumnChunkData from nested columns (String, Struct, List)
3. Add duplication check in FreeChunkMap
4. Fix comments left from previous PR #1 